### PR TITLE
VolumeSlider: Round displayed value to prevent decimal places

### DIFF
--- a/src/qml/VolumeSlider.qml
+++ b/src/qml/VolumeSlider.qml
@@ -55,7 +55,7 @@ Slider {
 
     Label {
         id: volumeLabel
-        text: root.value
+        text: Math.round(root.value)
         anchors.centerIn: root
         color: "#fff"
         layer.enabled: true


### PR DESCRIPTION
Description
This PR fixes the volume slider display to show clean integer values instead of long decimal numbers when scrolling with the mouse wheel.

Problem
Previously, when adjusting the volume using the mouse scroll wheel on the volume slider, it would display values with many decimal places (e.g., 56.6666666), which looked unprofessional and was difficult to read.

Solution
Applied Math.round() to the volume slider's display value to round it to the nearest integer. The underlying volume control still works with the precise decimal values, but the UI now shows clean numbers like 57.

before

<img width="147" height="55" alt="image" src="https://github.com/user-attachments/assets/318b3122-e1ce-43dd-b7cf-ad861be0d548" />

after

<img width="140" height="58" alt="image" src="https://github.com/user-attachments/assets/55db0eb9-f491-4480-bcab-7db506d3d0f2" />
